### PR TITLE
Adding the Data Mesh concept.

### DIFF
--- a/Concepts/Data Mesh.md
+++ b/Concepts/Data Mesh.md
@@ -1,0 +1,32 @@
+---
+Aliases: []
+Tags: [seedling]
+publish: false
+---
+
+Data Mesh is an analytical data architecture and operating model where data is treated as a product, leveraging a domain-driven and self-serve design.
+
+## The four principles of Data Mesh
+
+1. **Domain Ownership**: Arranging Data in Domains and declaring full end-to-end ownership
+2. **Data as a Product**: Applying Product-thinking to Data Assets and bridging the gap  between Producers and Consumers
+3. **Self-serve Data Platform**: Removing the intricancies of Infrastructure provisioning to enable domain autonomy and shorten lifecycles
+4. **Federated Computational Governance**: Seeking interoperability through global standardization
+
+
+## Data Mesh Advantages
+
+- Better Data Governance
+- Improved Data Quality
+- Data Products are built thinking on the consumer's needs first
+- Fine-grained Access by Domain
+
+## Data Mesh Disadvantages
+
+- The decentralisation of data is challenging. It requires changes not only technically, but also at organizational and mindset levels.
+
+%% wiki footer: Please don't edit anything below this line %%
+
+## This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/data-engineering-community/data-engineering-wiki/blob/main/Concepts/Untitled.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/data-engineering-community/data-engineering-wiki/main/Concepts/Untitled.md "git-hub-copy-note") </span>

--- a/Concepts/Data Mesh.md
+++ b/Concepts/Data Mesh.md
@@ -1,7 +1,7 @@
 ---
 Aliases: []
 Tags: [seedling]
-publish: false
+publish: true
 ---
 
 Data Mesh is an analytical data architecture and operating model where data is treated as a product, leveraging a domain-driven and self-serve design.
@@ -29,4 +29,4 @@ Data Mesh is an analytical data architecture and operating model where data is t
 
 ## This note in GitHub
 
-<span class="git-footer">[Edit In GitHub](https://github.dev/data-engineering-community/data-engineering-wiki/blob/main/Concepts/Untitled.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/data-engineering-community/data-engineering-wiki/main/Concepts/Untitled.md "git-hub-copy-note") </span>
+<span class="git-footer">[Edit In GitHub](https://github.dev/data-engineering-community/data-engineering-wiki/blob/main/Concepts/Data%20Mesh.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/data-engineering-community/data-engineering-wiki/main/Concepts/Data%20Mesh.md "git-hub-copy-note") </span>


### PR DESCRIPTION
Adding the Data Mesh concept to the wiki. Should automatically link from [the Popular Data Architecture Patterns](https://github.com/data-engineering-community/data-engineering-wiki/blob/main/Concepts/Data%20Architecture.md#popular-data-architecture-patterns) section under Data Architecture. 