### PR TITLE
New projects page

### DIFF
--- a/Community/Projects.md
+++ b/Community/Projects.md
@@ -1,0 +1,18 @@
+---
+Aliases: []
+Tags: []
+publish: true
+---
+
+> [!success]- [Submit your own project](https://airtable.com/appDgaRSGl09yvjFj/pagmImKixEISPcGQz/form)
+
+<iframe class="airtable-embed" src="https://airtable.com/embed/appDgaRSGl09yvjFj/shrlkViJZ90JZTHmu?backgroundColor=yellow&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="850" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+%% wiki footer: Please don't edit anything below this line %%
+
+## This note in GitHub
+
+<span class="git-footer">[Edit In GitHub](https://github.dev/data-engineering-community/data-engineering-wiki/blob/main/Community/Projects.md "git-hub-edit-note") | [Copy this note](https://raw.githubusercontent.com/data-engineering-community/data-engineering-wiki/main/Community/Projects.md "git-hub-copy-note")</span>
+
+<span class="git-footer">Was this page helpful?
+[👍](https://tally.so/r/mOaxjk?rating=Yes&url=https://dataengineering.wiki/Community/Projects) or [👎](https://tally.so/r/mOaxjk?rating=No&url=https://dataengineering.wiki/Community/Projects)</span>


### PR DESCRIPTION
Closes #40 

Adds a new page displaying a gallery of open source data engineering projects with links, images (optional), and tags for the tools used. I also added a form so folks can submit their own in the future.